### PR TITLE
fix: handle IPv4-mapped IPv6 addresses in UDPAddr conversion

### DIFF
--- a/common/metadata/addr.go
+++ b/common/metadata/addr.go
@@ -177,7 +177,9 @@ func AddrPortFromNet(netAddr net.Addr) netip.AddrPort {
 		ip = addr.IP
 		port = uint16(addr.Port)
 	case *net.UDPAddr:
-		ip = addr.IP
+		if ip = addr.IP.To4(); ip == nil {
+			ip = addr.IP
+		}
 		port = uint16(addr.Port)
 	case *net.IPAddr:
 		ip = addr.IP


### PR DESCRIPTION
https://github.com/MetaCubeX/sing/blob/2755c231f6e61a6bc5503f481e868b3a707aef3e/common/metadata/addr.go#L109

修改debug模式下的hysteria2协议此函数会抛出panic

<img width="675" height="71" alt="图片" src="https://github.com/user-attachments/assets/26cf1172-6ef3-4e9b-9681-e0f7057ed61b" />
